### PR TITLE
Menu CMS rearrangement

### DIFF
--- a/content/give.md
+++ b/content/give.md
@@ -1,4 +1,5 @@
 ---
+type: link
 title: Give Online
 external_url: "https://tithe.ly/give?c=2694797" 
 menu:

--- a/content/plan-your-visit.md
+++ b/content/plan-your-visit.md
@@ -1,4 +1,5 @@
 ---
+type: page
 menu:
   main:
     name: "Visit"

--- a/content/the-gospel.md
+++ b/content/the-gospel.md
@@ -1,4 +1,5 @@
 ---
+type: page
 menu:
   main:
     name: "Salvation"

--- a/content/watch.md
+++ b/content/watch.md
@@ -1,4 +1,5 @@
 ---
+type: link
 title: Watch Live
 external_url: "https://www.youtube.com/@anchorbaptistchurchslc/streams"
 menu:

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -92,7 +92,7 @@ collections:
     create: true
     filter: {field: "isEvent", value: true}
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    summary: "{{slug}} / {{filename}}.{{extension}}"
+    summary: "{{title}} / {{filename}}.{{extension}}"
     sortable_fields: ["title", "dates.start", "expiryDate"]
     fields:
       - {label: "Title", name: "title", widget: "string"}
@@ -155,6 +155,7 @@ collections:
     create: true
     folder: "content"
     filter: {field: "type", value: "page"}
+    summary: "[{{menu.main.weight}}] /{{filename}}/ - {{title}}"
     sortable_fields: ["menu.main.weight", "title"]
     fields:
       - { label: "Type", name: "type", widget: "hidden", default: "page"}
@@ -198,6 +199,8 @@ collections:
     label_singular: "About Page"
     description: "These are the About section pages."
     folder: "content/about"
+    sortable_fields: ["menu.main.weight", "title"]
+    summary: "[{{menu.main.weight}}] /about/{{filename}}/ - {{title}}"
     create: true
     fields:
       - { label: "Page Layout", name: "layout", widget: "select", required: false, options: ["single", "two-column"]}
@@ -225,7 +228,7 @@ collections:
             widget: "object"
             fields:
               - { label: "Name", name: "name", widget: "string" }
-              - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
+              - { label: "Weight", name: "weight", widget: "number", required: false, hint: "Lower numbers appear first in the menu" }
               - { label: "Parent", name: "parent", widget: "select", default: "about", required: false, options: ["about"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"
@@ -240,6 +243,8 @@ collections:
     label_singular: "Ministry Page"
     description: "These are the Ministry section pages."
     folder: "content/ministries"
+    sortable_fields: ["menu.main.weight", "title"]
+    summary: "[{{menu.main.weight}}] /ministries/{{filename}}/ - {{title}}"
     create: true
     fields:
       - { label: "Page Layout", name: "layout", widget: "select", required: false, options: ["single", "two-column"]}
@@ -278,7 +283,7 @@ collections:
             widget: "object"
             fields:
               - { label: "Name", name: "name", widget: "string" }
-              - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
+              - { label: "Weight", name: "weight", widget: "number", required: false, hint: "Lower numbers appear first in the menu" }
               - { label: "Parent", name: "parent", widget: "select", default: "ministries", required: false, options: ["ministries"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -139,7 +139,7 @@ collections:
             fields:
               - { label: "Name", name: "name", widget: "string", required: false }
               - { label: "Weight", name: "weight", widget: "number", required: false, hint: "Lower numbers appear first in the menu" }
-              - { label: "Parent", name: "parent", widget: "string", required: false, hint: "The identifier of the parent menu item (e.g., 'about', 'ministries')" }
+              - { label: "Parent", name: "parent", widget: "select", required: false, options: ["about", "ministries"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"
             required: false
@@ -200,6 +200,7 @@ collections:
     folder: "content/about"
     create: true
     fields:
+      - { label: "Page Layout", name: "layout", widget: "select", required: false, options: ["single", "two-column"]}
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Description", name: "description", widget: "string", hint: "Used for SEO metadata - keep it concise and on a single line" }
       - { label: "Featured Image", name: "featured_image", widget: "image" }
@@ -225,7 +226,7 @@ collections:
             fields:
               - { label: "Name", name: "name", widget: "string" }
               - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
-              - { label: "Parent", name: "parent", widget: "select", default: "about", required: false, options: ["about", "ministries"], hint: "Parent menu" }
+              - { label: "Parent", name: "parent", widget: "select", default: "about", required: false, options: ["about"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"
             required: false
@@ -241,6 +242,7 @@ collections:
     folder: "content/ministries"
     create: true
     fields:
+      - { label: "Page Layout", name: "layout", widget: "select", required: false, options: ["single", "two-column"]}
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Description", name: "description", widget: "string", hint: "Used for SEO metadata - keep it concise and on a single line" }
       - { label: "Featured Image", name: "featured_image", widget: "image" }
@@ -277,7 +279,7 @@ collections:
             fields:
               - { label: "Name", name: "name", widget: "string" }
               - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
-              - { label: "Parent", name: "parent", widget: "select", default: "ministries", required: false, options: ["about", "ministries"], hint: "Parent menu" }
+              - { label: "Parent", name: "parent", widget: "select", default: "ministries", required: false, options: ["ministries"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"
             required: false

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -93,6 +93,7 @@ collections:
     filter: {field: "isEvent", value: true}
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     summary: "{{slug}} / {{filename}}.{{extension}}"
+    sortable_fields: ["title", "dates.start", "expiryDate"]
     fields:
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Description", name: "description", widget: "string", hint: "Shows in the banner and on the list page."}
@@ -115,91 +116,87 @@ collections:
           render: false
         }}
 
-  - name: "plan-your-visit"
-    label: "Visit"
-    files:
-      - name: "plan-your-visit"
-        file: "content/plan-your-visit.md"
-        label: "Plan Your Visit"
+  - name: "menu-items"
+    label: "Menu Links"
+    label_singular: "Link"
+    description: "These are links that show in the menus. They are not a full pages on the site. Use these to have menu items that link to external places such as Youtube."
+    create: true
+    folder: "content"
+    filter: {field: "type", value: "link"}
+    fields:
+      - {label: "Type", name: "type", widget: "hidden", default: "link"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "URL", name: "external_url", widget: "string"}
+      - label: "Menu Configuration"
+        name: "menu"
+        required: false
+        widget: "object"
         fields:
-          - { label: "Title", name: "title", widget: "string" }
-          - { label: "Description", name: "description", widget: "string", hint: "Used for SEO metadata - keep it concise and on a single line" }
-          - { label: "Featured Image", name: "featured_image", widget: "image" }
-          - { label: "Tagline", name: "tagline", widget: "string" }
-          - { label: "Body", name: "body", widget: "markdown" }
-          - label: "Content Images"
-            name: "content_images"
-            required: false
-            widget: "list"
-            fields:
-              - { label: "Image", name: "image", widget: "image" }
-              - { label: "Alt Text", name: "alt_text", widget: "string" }
-              - { label: "Caption", name: "caption", widget: "string", required: false }
-          - label: "Menu Configuration"
-            name: "menu"
+          - label: "Main Menu"
+            name: "main"
             required: false
             widget: "object"
             fields:
-              - label: "Main Menu"
-                name: "main"
-                required: false
-                widget: "object"
-                fields:
-                  - { label: "Name", name: "name", widget: "string" }
-                  - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
-                  - { label: "Parent", name: "parent", widget: "string", required: false, hint: "The identifier of the parent menu item (e.g., 'about', 'ministries')" }
-              - label: "Footer Menu"
-                name: "footer"
-                required: false
-                widget: "object"
-                fields:
-                  - { label: "Name", name: "name", widget: "string", required: false }
-                  - { label: "Weight", name: "weight", widget: "number", required: false }
+              - { label: "Name", name: "name", widget: "string", required: false }
+              - { label: "Weight", name: "weight", widget: "number", required: false, hint: "Lower numbers appear first in the menu" }
+              - { label: "Parent", name: "parent", widget: "string", required: false, hint: "The identifier of the parent menu item (e.g., 'about', 'ministries')" }
+          - label: "Footer Menu"
+            name: "footer"
+            required: false
+            widget: "object"
+            fields:
+              - { label: "Name", name: "name", widget: "string", required: false }
+              - { label: "Weight", name: "weight", widget: "number", required: false }
 
-  - name: "the-gospel"
-    label: "Salvation"
-    files:
-      - name: "the-gospel"
-        file: "content/the-gospel.md"
-        label: "The Gospel"
+  - name: "main-pages"
+    label: "Main Pages"
+    label_singular: "Page"
+    description: "These are the pages at the top level of the site content structure."
+    create: true
+    folder: "content"
+    filter: {field: "type", value: "page"}
+    sortable_fields: ["menu.main.weight", "title"]
+    fields:
+      - { label: "Type", name: "type", widget: "hidden", default: "page"}
+      - { label: "Page Layout", name: "layout", widget: "select", default: "single", options: ["single", "two-column"]}
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Description", name: "description", widget: "string", hint: "Used for SEO metadata - keep it concise and on a single line" }
+      - { label: "Featured Image", name: "featured_image", widget: "image" }
+      - { label: "Tagline", name: "tagline", widget: "string" }
+      - { label: "Body", name: "body", widget: "markdown" }
+      - label: "Content Images"
+        name: "content_images"
+        required: false
+        widget: "list"
         fields:
-          - { label: "Title", name: "title", widget: "string" }
-          - { label: "Description", name: "description", widget: "string", hint: "Used for SEO metadata - keep it concise and on a single line" }
-          - { label: "Featured Image", name: "featured_image", widget: "image" }
-          - { label: "Tagline", name: "tagline", widget: "string" }
-          - { label: "Body", name: "body", widget: "markdown" }
-          - label: "Content Images"
-            name: "content_images"
-            required: false
-            widget: "list"
-            fields:
-              - { label: "Image", name: "image", widget: "image" }
-              - { label: "Alt Text", name: "alt_text", widget: "string" }
-              - { label: "Caption", name: "caption", widget: "string", required: false }
-          - label: "Menu Configuration"
-            name: "menu"
+          - { label: "Image", name: "image", widget: "image" }
+          - { label: "Alt Text", name: "alt_text", widget: "string" }
+          - { label: "Caption", name: "caption", widget: "string", required: false }
+      - label: "Menu Configuration"
+        name: "menu"
+        required: false
+        widget: "object"
+        fields:
+          - label: "Main Menu"
+            name: "main"
             required: false
             widget: "object"
             fields:
-              - label: "Main Menu"
-                name: "main"
-                required: false
-                widget: "object"
-                fields:
-                  - { label: "Name", name: "name", widget: "string" }
-                  - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
-                  - { label: "Parent", name: "parent", widget: "string", required: false, hint: "The identifier of the parent menu item (e.g., 'about', 'ministries')" }
-              - label: "Footer Menu"
-                name: "footer"
-                required: false
-                widget: "object"
-                fields:
-                  - { label: "Name", name: "name", widget: "string", required: false }
-                  - { label: "Weight", name: "weight", widget: "number", required: false }
+              - { label: "Name", name: "name", widget: "string", required: false }
+              - { label: "Weight", name: "weight", widget: "number", required: false, hint: "Lower numbers appear first in the menu" }
+              - { label: "Parent", name: "parent", widget: "select", required: false, options: ["about", "ministries"], hint: "Parent menu" }
+          - label: "Footer Menu"
+            name: "footer"
+            required: false
+            widget: "object"
+            fields:
+              - { label: "Name", name: "name", widget: "string", required: false }
+              - { label: "Weight", name: "weight", widget: "number", required: false }
 
   - name: "about-pages"
     label: "About Pages"
     label_singular: "About Page"
+    description: "These are the About section pages."
     folder: "content/about"
     create: true
     fields:
@@ -228,7 +225,7 @@ collections:
             fields:
               - { label: "Name", name: "name", widget: "string" }
               - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
-              - { label: "Parent", name: "parent", widget: "string", default: "about", required: false, hint: "The identifier of the parent menu item (e.g., 'about', 'ministries')" }
+              - { label: "Parent", name: "parent", widget: "select", default: "about", required: false, options: ["about", "ministries"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"
             required: false
@@ -240,6 +237,7 @@ collections:
   - name: "ministry-pages"
     label: "Ministry Pages"
     label_singular: "Ministry Page"
+    description: "These are the Ministry section pages."
     folder: "content/ministries"
     create: true
     fields:
@@ -279,7 +277,7 @@ collections:
             fields:
               - { label: "Name", name: "name", widget: "string" }
               - { label: "Weight", name: "weight", widget: "number", hint: "Lower numbers appear first in the menu" }
-              - { label: "Parent", name: "parent", widget: "string", default: "ministries", required: false, hint: "The identifier of the parent menu item (e.g., 'about', 'ministries')" }
+              - { label: "Parent", name: "parent", widget: "select", default: "ministries", required: false, options: ["about", "ministries"], hint: "Parent menu" }
           - label: "Footer Menu"
             name: "footer"
             required: false

--- a/themes/anchor-theme/assets/js/cms/components/MenuPreview.jsx
+++ b/themes/anchor-theme/assets/js/cms/components/MenuPreview.jsx
@@ -1,0 +1,53 @@
+/**
+ * MenuPreview component for the CMS
+ * Displays a preview of the menu structure
+ */
+import { PreviewHeader } from './PreviewHeader.jsx';
+
+export const MenuPreview = createClass({
+  render() {
+    const entry = this.props.entry;
+    const data = entry.getIn(['data']).toJS();
+    const menuConfig = data.menu || {};
+
+    return (
+      <div className="bg-white">
+        {/* Header */}
+        <PreviewHeader
+          title="Menu Item Preview"
+          listItems={[
+            "Main menu items appear in the top navigation",
+            "Items with parents appear in dropdown menus",
+            "Footer menu items appear in the site footer"
+          ]}
+        />
+
+        {/* Menu Configuration Details */}
+        <div className="container mx-auto px-4 py-8">
+          <div className="bg-gray-50 p-6 rounded-lg shadow-sm">
+            <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {menuConfig.main && (
+                <>
+                  <dt className="font-medium">Main Link:</dt>
+                  <dd className="mx-2"><a href={data.external_url} target="_blank">{menuConfig.main.name || data.title}</a></dd>
+                  <dt className="font-medium">Weight/Position:</dt>
+                  <dd className="mx-2">{menuConfig.main?.weight || 'Not set'}</dd>
+                  <dt className="font-medium">Parent:</dt>
+                  <dd className="mx-2">{menuConfig.main.parent || 'None (Top Level)'}</dd>
+                </>
+              )}
+              {menuConfig.footer && (
+                <>
+                  <dt className="font-medium">Footer Link:</dt>
+                  <dd className="mx-2"><a href={data.external_url} target="_blank">{menuConfig.footer.name || data.title}</a></dd>
+                  <dt className="font-medium">Weight/Position:</dt>
+                  <dd className="mx-2">{menuConfig.footer?.weight || 'Not set'}</dd>
+                </>
+              )}
+            </dl>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});

--- a/themes/anchor-theme/assets/js/cms/index.js
+++ b/themes/anchor-theme/assets/js/cms/index.js
@@ -8,12 +8,14 @@ import { HomePreview } from './components/HomePreview.jsx';
 import { MinistryPreview } from './components/MinistryPreview.jsx';
 import { EventPreview } from './components/EventPreview.jsx';
 import { EventsListPreview } from './components/EventsListPreview.jsx';
+import { MenuPreview } from './components/MenuPreview.jsx';
 
 // Make components available globally
 window.HomePreview = HomePreview;
 window.MinistryPreview = MinistryPreview;
 window.EventPreview = EventPreview;
 window.EventsListPreview = EventsListPreview;
+window.MenuPreview = MenuPreview;
 
 // Export components for use in other parts of the application
 export {
@@ -21,4 +23,5 @@ export {
   MinistryPreview,
   EventPreview,
   EventsListPreview,
+  MenuPreview,
 }; 

--- a/themes/anchor-theme/layouts/_default/admin-standalone.html
+++ b/themes/anchor-theme/layouts/_default/admin-standalone.html
@@ -11,6 +11,18 @@
       [class*="StyledAuthenticationPage"] {
         background: #1a202c;
       }
+      /*
+      Use anchor-theme brand-light as the Decap CMS icon background color
+      so it stands out and is visible
+      */
+      [class*="StyledAuthenticationPage"] [class*="IconWrapper-NetlifyCreditIcon"] {
+        background-color: #6E879D;
+        width: 100%;
+        height: 40px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        bottom: 0px;
+      }
     </style>
 </head>
 <body>

--- a/themes/anchor-theme/layouts/_default/admin-standalone.html
+++ b/themes/anchor-theme/layouts/_default/admin-standalone.html
@@ -49,6 +49,7 @@
             CMS.registerPreviewTemplate('about-pages', window.MinistryPreview);
             CMS.registerPreviewTemplate('ministries', window.MinistryPreview);
             CMS.registerPreviewTemplate('ministry-pages', window.MinistryPreview);
+            CMS.registerPreviewTemplate('menu-items', window.MenuPreview);
         });
     </script>
 </body>

--- a/themes/anchor-theme/layouts/_default/admin-standalone.html
+++ b/themes/anchor-theme/layouts/_default/admin-standalone.html
@@ -42,14 +42,13 @@
         window.addEventListener('load', () => {
             // Register preview templates
             CMS.registerPreviewTemplate('home', window.HomePreview);
-            CMS.registerPreviewTemplate('plan-your-visit', window.MinistryPreview);
-            CMS.registerPreviewTemplate('the-gospel', window.MinistryPreview);
-            CMS.registerPreviewTemplate('ministries', window.MinistryPreview);
-            CMS.registerPreviewTemplate('ministry-pages', window.MinistryPreview);
+            CMS.registerPreviewTemplate('events-index', window.EventsListPreview);
+            CMS.registerPreviewTemplate('events-items', window.EventPreview);
+            CMS.registerPreviewTemplate('main-pages', window.MinistryPreview);
             CMS.registerPreviewTemplate('about', window.MinistryPreview); // Using same template as ministries since layout is similar
             CMS.registerPreviewTemplate('about-pages', window.MinistryPreview);
-            CMS.registerPreviewTemplate('events-items', window.EventPreview);
-            CMS.registerPreviewTemplate('events-index', window.EventsListPreview);
+            CMS.registerPreviewTemplate('ministries', window.MinistryPreview);
+            CMS.registerPreviewTemplate('ministry-pages', window.MinistryPreview);
         });
     </script>
 </body>


### PR DESCRIPTION
In the CMS editor some tweaks:
- Added a section to edit the menu links themselves
- Moved the top level pages into a top level folder to make adding more or editing these top level pages easier
- Added a selector for the template type to the editor [does not yet have full rendering support of the template options]
- Added a selector for the menu parent to make it painless to get menu structure right the first time
